### PR TITLE
chore: increase repo package security

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,6 +1,13 @@
+approvedGitRepositories:
+  - "**"
+
 dedupePluginMode: dependabot-only
 
+enableScripts: true
+
 nodeLinker: node-modules
+
+npmMinimalAgeGate: 0
 
 plugins:
   - checksum: c43fb18b0cc042871a14ddc76ec78d35b4bc6896ec1d2b75d137cfc6b6b3e2a83fe6cb8b1d2657700b460e81d843b8dc33c5330db1cce2cffe2d91ce0442eb14

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,13 +1,10 @@
-approvedGitRepositories:
-  - "**"
-
 dedupePluginMode: dependabot-only
 
-enableScripts: true
+enableScripts: false
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 0
+npmMinimalAgeGate: 1
 
 plugins:
   - checksum: c43fb18b0cc042871a14ddc76ec78d35b4bc6896ec1d2b75d137cfc6b6b3e2a83fe6cb8b1d2657700b460e81d843b8dc33c5330db1cce2cffe2d91ce0442eb14

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "eslint-plugin-rxjs-angular-x",
   "type": "module",
   "version": "1.0.1",
-  "packageManager": "yarn@4.13.0+sha512.5c20ba010c99815433e5c8453112165e673f1c7948d8d2b267f4b5e52097538658388ebc9f9580656d9b75c5cc996f990f611f99304a2197d4c56d21eea370e7",
+  "packageManager": "yarn@4.15.0+sha512.07ec708ac11e2eaa4ea2b04cfbb272812f7e74a753f1595eaef4486c663a98306a30cca3e6fc40f7a0b168dcfb3a2490b6a5e0501e20fb69cc36f563dd161c53",
   "description": "ESLint v9+ rules for RxJS and Angular",
   "author": "Jason Weinzierl <weinzierljason@gmail.com>",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
     "@typescript-eslint/utils": "^8.58.0",
     "ts-api-utils": "^2.5.0"
   },
+  "dependenciesMeta": {
+    "unrs-resolver": {
+      "built": false
+    }
+  },
   "peerDependencies": {
     "eslint": "^10.0.0",
     "rxjs": "^7.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1917,6 +1917,9 @@ __metadata:
     eslint: ^10.0.0
     rxjs: ^7.2.0
     typescript: ">=4.8.4 <6.1.0"
+  dependenciesMeta:
+    unrs-resolver:
+      built: false
   peerDependenciesMeta:
     rxjs:
       optional: true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10c0
 
 "@babel/code-frame@npm:^7.0.0":


### PR DESCRIPTION
- Disable package scripts
  - unrs-resolver is the only one in this repo, and its build script is optional
- Update yarn to a version that blocks git repos by default
- Enforce a minimum npm age gate