### PR TITLE
test: add fast-check fuzz tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@fast-check/vitest": "^0.4.1",
     "@stylistic/eslint-plugin": "^5.10.0",
     "@types/common-tags": "^1.8.4",
     "@types/node": "~20.19.33",
@@ -89,6 +90,7 @@
     "eslint-plugin-eslint-plugin": "^7.3.2",
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-n": "^17.24.0",
+    "fast-check": "^4.8.0",
     "markdownlint-cli2": "~0.22.0",
     "rxjs": "^7.8.2",
     "tsdown": "~0.21.7",

--- a/tests/fuzzing/rules.fuzz.test.ts
+++ b/tests/fuzzing/rules.fuzz.test.ts
@@ -1,0 +1,45 @@
+/**
+ * @file Verifies that rules do not crash when parsing arbitrary input.
+ */
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { fc, test } from '@fast-check/vitest';
+import { Linter } from 'eslint';
+import { parser as tseslintParser } from 'typescript-eslint';
+import rxjsAngularX from '../../src/index';
+
+const tsconfigRootDir = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+const fuzzFilename = path.join(tsconfigRootDir, 'file.ts');
+const allRules = Object.fromEntries(
+  Object.keys(rxjsAngularX.rules).map((rule) => [`rxjs-angular-x/${rule}`, 'error'] as const),
+);
+
+const linter = new Linter();
+
+// Similar to rule-tester.ts setup.
+const linterConfig = {
+  plugins: { 'rxjs-angular-x': rxjsAngularX },
+  rules: allRules,
+  languageOptions: {
+    parser: tseslintParser,
+    parserOptions: {
+      projectService: {
+        allowDefaultProject: ['*.ts*'],
+        defaultProject: 'tsconfig.json',
+      },
+      tsconfigRootDir,
+    },
+  },
+};
+
+test.prop([
+  fc.string({ unit: 'grapheme-ascii' }),
+])('rules do not throw on arbitrary ASCII text', code => {
+  linter.verify(code, linterConfig, fuzzFilename);
+});
+
+test.prop([
+  fc.string({ unit: 'grapheme' }),
+])('rules do not throw on arbitrary Unicode text', code => {
+  linter.verify(code, linterConfig, fuzzFilename);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -225,6 +225,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@fast-check/vitest@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@fast-check/vitest@npm:0.4.1"
+  dependencies:
+    fast-check: "npm:^3.0.0 || ^4.0.0"
+  peerDependencies:
+    vitest: ^4.1.0
+  checksum: 10c0/c558f443cbf79cfc18f81372d21129021a13e5d821b57876449d3cac254638ddc5c9736b687fc82dc78f53cf1d948a68787aff7f0d1700704168e1805af088d2
+  languageName: node
+  linkType: hard
+
 "@humanfs/core@npm:^0.19.1":
   version: 0.19.1
   resolution: "@humanfs/core@npm:0.19.1"
@@ -1889,6 +1900,7 @@ __metadata:
   resolution: "eslint-plugin-rxjs-angular-x@workspace:."
   dependencies:
     "@eslint/js": "npm:^10.0.1"
+    "@fast-check/vitest": "npm:^0.4.1"
     "@stylistic/eslint-plugin": "npm:^5.10.0"
     "@types/common-tags": "npm:^1.8.4"
     "@types/node": "npm:~20.19.33"
@@ -1905,6 +1917,7 @@ __metadata:
     eslint-plugin-eslint-plugin: "npm:^7.3.2"
     eslint-plugin-import-x: "npm:^4.16.2"
     eslint-plugin-n: "npm:^17.24.0"
+    fast-check: "npm:^4.8.0"
     markdownlint-cli2: "npm:~0.22.0"
     rxjs: "npm:^7.8.2"
     ts-api-utils: "npm:^2.5.0"
@@ -2078,6 +2091,15 @@ __metadata:
   version: 3.1.1
   resolution: "exponential-backoff@npm:3.1.1"
   checksum: 10c0/160456d2d647e6019640bd07111634d8c353038d9fa40176afb7cd49b0548bdae83b56d05e907c2cce2300b81cae35d800ef92fefb9d0208e190fa3b7d6bb579
+  languageName: node
+  linkType: hard
+
+"fast-check@npm:^3.0.0 || ^4.0.0, fast-check@npm:^4.8.0":
+  version: 4.8.0
+  resolution: "fast-check@npm:4.8.0"
+  dependencies:
+    pure-rand: "npm:^8.0.0"
+  checksum: 10c0/f72556a29db4ff386a8b6e50d420b06c7e5eaafff7db5560a99136c57d8d4777998155eb02d1bbeff396f575cc0b1442c8a1c4ddb798c4a919b542de1a1904ff
   languageName: node
   linkType: hard
 
@@ -3694,6 +3716,13 @@ __metadata:
   version: 2.1.1
   resolution: "punycode@npm:2.1.1"
   checksum: 10c0/83815ca9b9177f055771f31980cbec7ffaef10257d50a95ab99b4a30f0404846e85fa6887ee1bbc0aaddb7bad6d96e2fa150a016051ff0f6b92be4ad613ddca8
+  languageName: node
+  linkType: hard
+
+"pure-rand@npm:^8.0.0":
+  version: 8.4.0
+  resolution: "pure-rand@npm:8.4.0"
+  checksum: 10c0/6414bbc1c6f45fb774173431c7205e79783b77cfae0e2145e741b6999363554dbd2f4210d2a5bc08683e0b2f6823198c9308766b1d0911e1dccd7beb8842f860
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
All rules are tested for both arbitrary ASCII and Unicode input.
Satisfies OpenSSF Scorecard requirement for Fuzzing.